### PR TITLE
Update translation.json - EN

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -8,7 +8,7 @@
     "skip": "Skip",
     "verify": "Verify",
     "internetError": "Please reconnect to the internet to use this feature",
-    "send": "Send",
+    "send": "Approve",
     "decline": "Decline",
     "receive": "Receive",
     "accept": "Accept",


### PR DESCRIPTION
I think the context here is to approve or decline a payment request from a contact. So make sense approve word than send word. @BlakeKaufman