### PR TITLE
Update deposit method title in translation file

### DIFF
--- a/locales/en/translation.json
+++ b/locales/en/translation.json
@@ -1031,7 +1031,7 @@
       "roostockDesc": "Receive Rootstock BTC to your wallet.",
       "sparkDesc": "Receive BTC or tokens to your wallet.",
       "chooseMethodTitle": "Choose receive method",
-      "selectMethodTitle": "Select deposit method",
+      "selectMethodTitle": "Add funds",
       "copyAddress": "Copy Address",
       "depositQRError": "We ran into a problem when generating your {{addressType}} address",
       "changeReceiveCurrency": "Change receive currency",


### PR DESCRIPTION
(Select deposit method) for first page of modal doesn't look right. As now the first page is to choose which currency to deposit not the method, the title should be Add funds or Deposit money. cc @BlakeKaufman 

Thanks.